### PR TITLE
fix submit supervisor when druid is starting up

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Generate docker-compose.yml
         run: |
-          ./integration/rb_generate_compose.sh > docker-compose.yml
+          ./integration/rb_generate_compose.sh > ./integration/docker-compose.yml
 
       - name: Start Docker containers
         run: |

--- a/druid/router.go
+++ b/druid/router.go
@@ -29,6 +29,10 @@ import (
 )
 
 func GetSupervisors(routers []zkclient.DruidRouter) ([]string, error) {
+	if len(routers) == 0 {
+		return nil, fmt.Errorf("no available routers")
+	}
+
 	var allSupervisors []string
 
 	randomIndex := int(time.Now().UnixNano() % int64(len(routers)))
@@ -38,23 +42,23 @@ func GetSupervisors(routers []zkclient.DruidRouter) ([]string, error) {
 
 	resp, err := http.Get(url)
 	if err != nil {
-		logger.Log.Errorf("Failed to send GET request to %s: %v", url, err)
+		return nil, fmt.Errorf("failed to send GET request to %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		logger.Log.Warnf("Failed to fetch supervisors from %s, status code: %d", url, resp.StatusCode)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.Log.Errorf("Failed to read response body from %s: %v", url, err)
+		return nil, fmt.Errorf("failed to read response body from %s: %w", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch supervisors from %s, status code: %d, body: %s", url, resp.StatusCode, string(body))
 	}
 
 	var supervisors []string
 	err = json.Unmarshal(body, &supervisors)
 	if err != nil {
-		logger.Log.Errorf("Failed to unmarshal response from %s: %v", url, err)
+		return nil, fmt.Errorf("failed to unmarshal response from %s: %w", url, err)
 	}
 
 	logger.Log.Infof("Successfully fetched supervisors from %s: %v", url, supervisors)
@@ -63,10 +67,9 @@ func GetSupervisors(routers []zkclient.DruidRouter) ([]string, error) {
 	return allSupervisors, nil
 }
 
-func SubmitTask(routers []zkclient.DruidRouter, task string) {
+func SubmitTask(routers []zkclient.DruidRouter, task string) error {
 	if len(routers) == 0 {
-		logger.Log.Errorf("No available routers to submit the task")
-		return
+		return fmt.Errorf("no available routers to submit the task")
 	}
 
 	randomIndex := int(time.Now().UnixNano() % int64(len(routers)))
@@ -75,26 +78,27 @@ func SubmitTask(routers []zkclient.DruidRouter, task string) {
 	url := fmt.Sprintf("http://%s:%d/druid/indexer/v1/supervisor", router.Address, router.Port)
 	resp, err := http.Post(url, "application/json", strings.NewReader(task))
 	if err != nil {
-		logger.Log.Errorf("Error submitting task to %s: %v", url, err)
-		return
+		return fmt.Errorf("error submitting task to %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.Log.Errorf("Error reading response from %s: %v", url, err)
-		return
+		return fmt.Errorf("error reading response from %s: %w", url, err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		logger.Log.Warnf("Unexpected status code %d from %s, response: %s", resp.StatusCode, url, string(body))
-		return
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("unexpected status code %d from %s, response: %s", resp.StatusCode, url, string(body))
 	}
 
 	logger.Log.Infof("Task submitted successfully to %s: %s", url, string(body))
+	return nil
 }
 
-func DeleteTask(routers []zkclient.DruidRouter, task string) {
+func DeleteTask(routers []zkclient.DruidRouter, task string) error {
+	if len(routers) == 0 {
+		return fmt.Errorf("no available routers")
+	}
 
 	randomIndex := int(time.Now().UnixNano() % int64(len(routers)))
 	router := routers[randomIndex]
@@ -102,20 +106,21 @@ func DeleteTask(routers []zkclient.DruidRouter, task string) {
 	url := fmt.Sprintf("http://%s:%d/druid/indexer/v1/supervisor/%s/terminate", router.Address, router.Port, task)
 	resp, err := http.Post(url, "application/json", strings.NewReader(task))
 	if err != nil {
-		logger.Log.Errorf("Error deleting task %s from %s: %v", task, url, err)
+		return fmt.Errorf("error deleting task %s from %s: %w", task, url, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.Log.Errorf("Error reading response for task %s from %s: %v", task, url, err)
+		return fmt.Errorf("error reading response for task %s from %s: %w", task, url, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		logger.Log.Warnf("Unexpected status code %d for task %s from %s, response: %s", resp.StatusCode, task, url, string(body))
+		return fmt.Errorf("unexpected status code %d for task %s from %s, response: %s", resp.StatusCode, task, url, string(body))
 	}
 
 	logger.Log.Infof("Task %s deleted successfully from %s: %s", task, url, string(body))
+	return nil
 }
 
 type ActiveTask struct {

--- a/integration/rb_run_integration_tests.sh
+++ b/integration/rb_run_integration_tests.sh
@@ -3,37 +3,68 @@
 DRUID_HOST="localhost:8888"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PATH="$SCRIPT_DIR/rb_produce_syn_data.sh"
+
+echo "Producing test data to Kafka..."
 bash "$SCRIPT_PATH"
 
-echo "Checking for all Druid supervisors..."
+echo "Waiting for Druid supervisor 'rb_flow' to be active..."
 
-SUPERVISOR_TASK_STATUS=$(curl -s -X GET "$DRUID_HOST/druid/indexer/v1/supervisor")
+MAX_RETRIES=30
+RETRY_COUNT=0
+SUPERVISOR_FOUND=false
 
-echo "Supervisor Task Status:"
-echo "$SUPERVISOR_TASK_STATUS"
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+  SUPERVISOR_TASK_STATUS=$(curl -s -X GET "$DRUID_HOST/druid/indexer/v1/supervisor")
+  
+  if echo "$SUPERVISOR_TASK_STATUS" | grep -q "rb_flow"; then
+    echo "Supervisor task 'rb_flow' found!"
+    SUPERVISOR_FOUND=true
+    break
+  fi
 
-if [[ "$SUPERVISOR_TASK_STATUS" == "[]" ]]; then
-  echo "No supervisors found. Exiting with failure."
-  exit 1
-else
-  echo "Supervisor tasks found."
-fi
+  echo "Waiting for supervisor 'rb_flow'... (Attempt $((RETRY_COUNT+1))/$MAX_RETRIES). Current response: $SUPERVISOR_TASK_STATUS"
+  sleep 5
+  RETRY_COUNT=$((RETRY_COUNT+1))
+done
 
-DRUID_TASK_DATA=$(curl -s -o response.json -w "%{http_code}" -X POST -H "Content-Type: application/json" \
-  -d '{"query": "SELECT * FROM rb_flow"}' \
-  "$DRUID_HOST/druid/v2/sql")
-
-HTTP_STATUS="${DRUID_TASK_DATA: -3}"
-
-echo "HTTP Status: $HTTP_STATUS"
-echo "Druid Query Result:"
-cat response.json
-
-if [ "$HTTP_STATUS" -eq 200 ]; then
-  echo "Druid query successful."
-else
-  echo "Druid query failed with status code $HTTP_STATUS. Exiting with failure."
+if [ "$SUPERVISOR_FOUND" = false ]; then
+  echo "Supervisor task 'rb_flow' was not registered in time. Exiting with failure."
   exit 1
 fi
 
+echo "Waiting for Druid SQL query on 'rb_flow' to return data..."
+
+MAX_QUERY_RETRIES=24
+QUERY_RETRY_COUNT=0
+QUERY_SUCCESS=false
+
+while [ $QUERY_RETRY_COUNT -lt $MAX_QUERY_RETRIES ]; do
+  DRUID_TASK_DATA=$(curl -s -o response.json -w "%{http_code}" -X POST -H "Content-Type: application/json" \
+    -d '{"query": "SELECT * FROM rb_flow"}' \
+    "$DRUID_HOST/druid/v2/sql")
+
+  HTTP_STATUS="${DRUID_TASK_DATA: -3}"
+
+  if [ "$HTTP_STATUS" -eq 200 ]; then
+    echo "Druid query successful (HTTP status 200)."
+    echo "Druid Query Result:"
+    cat response.json
+    QUERY_SUCCESS=true
+    break
+  fi
+
+  echo "Druid query pending (HTTP $HTTP_STATUS)... (Attempt $((QUERY_RETRY_COUNT+1))/$MAX_QUERY_RETRIES)"
+  sleep 5
+  QUERY_RETRY_COUNT=$((QUERY_RETRY_COUNT+1))
+done
+
+if [ "$QUERY_SUCCESS" = false ]; then
+  echo "Druid query failed after retries. Last HTTP Status: $HTTP_STATUS"
+  echo "Last Druid Query Response:"
+  cat response.json
+  exit 1
+fi
+
+echo "Integration test completed successfully!"
 exit 0
+

--- a/main.go
+++ b/main.go
@@ -113,15 +113,15 @@ func main() {
 
 		routers, err := zkclient.GetDruidRouterInfo(zk.GetConn(), cfg.RouterDiscoveryPath)
 		if err != nil {
-			logger.Log.Errorf("Error retrieving Druid Router info from ZooKeeper: %v. Retrying in 60s...", err)
-			time.Sleep(60 * time.Second)
+			logger.Log.Errorf("Error retrieving Druid Router info from ZooKeeper: %v. Retrying in 10s...", err)
+			time.Sleep(10 * time.Second)
 			continue
 		}
 
 		supervisorTasks, err := druidrouter.GetSupervisors(routers)
 		if err != nil {
-			logger.Log.Errorf("Failed to get supervisor tasks: %v. Retrying in 60s...", err)
-			time.Sleep(60 * time.Second)
+			logger.Log.Errorf("Failed to get supervisor tasks: %v. Retrying in 10s...", err)
+			time.Sleep(10 * time.Second)
 			continue
 		}
 
@@ -148,7 +148,9 @@ func main() {
 				}
 				if !isPresent {
 					logger.Log.Infof("Supervisor %s is no longer in the configuration. Terminating it.", taskName)
-					druidrouter.DeleteTask(routers, taskName)
+					if err := druidrouter.DeleteTask(routers, taskName); err != nil {
+						logger.Log.Errorf("Failed to delete obsolete supervisor %s: %v", taskName, err)
+					}
 				}
 			}
 
@@ -214,7 +216,9 @@ func main() {
 			if isEmpty {
 				if isSupervisorRunning {
 					logger.Log.Infof("Topic %s is empty. Terminating supervisor task %s to free resources.", taskConfig.Feed, taskConfig.TaskName)
-					druidrouter.DeleteTask(routers, taskConfig.TaskName)
+					if err := druidrouter.DeleteTask(routers, taskConfig.TaskName); err != nil {
+						logger.Log.Errorf("Failed to delete supervisor task %s: %v", taskConfig.TaskName, err)
+					}
 				} else {
 					logger.Log.Debugf("Topic %s is empty and supervisor task %s is not running. Skipping.", taskConfig.Feed, taskConfig.TaskName)
 				}
@@ -245,7 +249,9 @@ func main() {
 						logger.Log.Fatalf("Error generating config for task %s: %v", taskConfig.TaskName, err)
 					}
 
-					druidrouter.SubmitTask(routers, jsonStr)
+					if err := druidrouter.SubmitTask(routers, jsonStr); err != nil {
+						logger.Log.Errorf("Failed to submit supervisor task %s: %v", taskConfig.TaskName, err)
+					}
 				} else {
 					logger.Log.Debugf("Topic %s has messages and supervisor task %s is already running.", taskConfig.Feed, taskConfig.TaskName)
 


### PR DESCRIPTION
Fixes the submission of supervisors when Druid is starting up. SubmitTask now accepts the HTTP 202 (Accepted) response returned by Druid during startup (previously, it treated this as an error and discarded the submission). Additionally, the functions in router.go now return an error instead of just logging, and the retry interval is reduced from 60s to 10s for faster recovery. The integration test is adjusted to wait,  with retries, until the rb_flow supervisor becomes active.